### PR TITLE
feat: adiciona pre-commit ao ci

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -1,0 +1,14 @@
+run-name: Continuous Integration (pre-commit)
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+    - uses: pre-commit/action@v3.0.1


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow for continuous integration. The workflow, defined in `.github/workflows/pre-commit.yaml`, is triggered on pull requests and pushes to the main branch. It sets up a job that runs on the latest version of Ubuntu, checks out the code, sets up Python, and then runs pre-commit checks.

Key change:

* [`.github/workflows/pre-commit.yaml`](diffhunk://#diff-3c0d80ea54e617ba55ba031dda6fc983852272f93775375ce402a66a03560548R1-R14): Added a new continuous integration workflow that runs pre-commit checks on pull requests and pushes to the main branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Introduced a continuous integration workflow to run pre-commit checks on pull requests and main branch updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->